### PR TITLE
Use `Services.strings.createBundle` instead of relying on the `StringBundle`, since it's been removed in Firefox 55 (issue 46)

### DIFF
--- a/modules/Australis.jsm
+++ b/modules/Australis.jsm
@@ -26,9 +26,8 @@ const DEFAULT_WIDGETS = [WIDGET_ID_STATUS, WIDGET_ID_PROGRESS, WIDGET_ID_DOWNLOA
 
 CU.import("resource:///modules/CustomizableUI.jsm");
 CU.import("resource://gre/modules/Services.jsm");
-CU.import("resource://services-common/stringbundle.js");
 
-const strings = new StringBundle("chrome://status4evar/locale/overlay.properties");
+const strings = Services.strings.createBundle("chrome://status4evar/locale/overlay.properties");
 
 CustomizableUI.registerArea(STATUS_BAR_ID, {
 	type: CustomizableUI.TYPE_TOOLBAR,


### PR DESCRIPTION
In [bug 1335877](https://bugzilla.mozilla.org/show_bug.cgi?id=1335877), see also commit https://hg.mozilla.org/mozilla-central/rev/18b7e4434612, `resource://services-common/stringbundle.js` was removed.

This patch will allow the addon to work in Firefox 55 (and up), and as far as I can tell `StringBundle` has actually been deprecated for quite some time.

Fixes #46.